### PR TITLE
Fix npm3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /node_modules/
+.idea/

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 var Promise = require('bluebird'),
     request = require('request'),
     prequest = Promise.promisify(request),
-    tough = require('request/node_modules/tough-cookie');
+    tough = require('tough-cookie');
 
 var defaultHeaders = {
   'accept':'application/json, text/javascript, */*; q=0.01',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pquest",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "description": "Promisified request with persistant cookies and retry",
   "main": "index.js",
   "scripts": {
@@ -10,7 +10,6 @@
     "type": "git",
     "url": "http://github.com/ZJONSSON/pquest.git"
   },
-  "main": "index.js",
   "author": "(c) Ziggy Jonsson (http://github.com/zjonsson/)",
   "license": "MIT",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "license": "MIT",
   "dependencies": {
     "bluebird": "^2.9.27",
-    "request": "^2.57.0"
+    "request": "^2.57.0",
+    "tough-cookie": "^2.2.1"
   }
 }


### PR DESCRIPTION
Hi Ziggy,

NPM 3 has changed so that it installs module dependencies in a flat structure (there's a section called Flat, Flat, Flat that goes into the details [here](https://github.com/npm/npm/releases/tag/v3.0.0)). So, in order to require `tough-cookie`, I'd like to propose adding it directly to the `package.json` as a dependency and changing the require statement to point directly to `tough-cookie`, rather than `request/node_modules/tough-cookie`.

Gabe
