### PR TITLE
Bump tough-cookie and request

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "license": "MIT",
   "dependencies": {
     "bluebird": "~3.3.1",
-    "request": "~2.69.0",
-    "tough-cookie": "~2.2.1"
+    "request": "~2.76.0",
+    "tough-cookie": "~2.3.2"
   }
 }


### PR DESCRIPTION
Old version was vulnerable to ReDoS https://nodesecurity.io/advisories/130
